### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Features.
 
 使用
 -------
-####安装 activate-power-mode 之后 到 Window > activate-power-mode 就可以开启或者关闭相对应的效果
+#### 安装 activate-power-mode 之后 到 Window > activate-power-mode 就可以开启或者关闭相对应的效果
 
 开发
 -------
 
-####下载
+#### 下载
 >git clone https://github.com/ViceFantasyPlace/activate-power-mode.git
 
-####第一次运行如果没有运行配置需要创建一个Plugin的Configuration
+#### 第一次运行如果没有运行配置需要创建一个Plugin的Configuration
 >Edit Run/Debug Configurations <br>
 >-> add a new Plugin Configuration <br>
 >-> 在 Use classpath of module 选择 activate-power-mode <br>
@@ -34,12 +34,12 @@ Features.
 安装
 -------
 
-####下载jar包
+#### 下载jar包
 [在Jetbrains plugin repositories上下载](https://plugins.jetbrains.com/plugin/8330?pr=idea)
 
 [直接在release下载](https://github.com/ViceFantasyPlace/activate-power-mode/releases)
 
-####安装 Plugin jar包
+#### 安装 Plugin jar包
 >Preferences/Plugins <br>
 >-> Install plugin from disk <br>
 >-> 选择 jar文件 <br>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
